### PR TITLE
Amended the anchor color

### DIFF
--- a/assets/documenter.admin.css
+++ b/assets/documenter.admin.css
@@ -85,10 +85,11 @@
 
 #documenter-drawer a {
 	text-decoration: underline;
+	color: #6f9bda;
 }
 
 #documenter-drawer a:hover {
-	color: #000;
+	color: #93bfff;
 	border: none;
 }
 


### PR DESCRIPTION
To contrast better with the very dark drawer background, especially the `:hover` pseudoclass which was black!

BTW, this is my first ever PR. @nitriques suggested I edit in github.com UI. I don't know why this branch is called `patch-1`. I thought I was editing `master`. In fact, I double-checked. Maybe it's an automatically generated name.